### PR TITLE
Correção no Select de entrada/saida

### DIFF
--- a/entradas/forms/entrada_form.py
+++ b/entradas/forms/entrada_form.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from entradas.models import Entradas
+from entradas.models import Entradas, Categorias_Entradas
 
 
 class EntradasForm(forms.ModelForm):
@@ -39,3 +39,9 @@ class EntradasForm(forms.ModelForm):
             'descricao': 'Descrição',
             'valor': 'Valor',
         }
+
+    def __init__(self, *args, **kwargs):
+            usuario = kwargs.pop('usuario', None)
+            super().__init__(*args, **kwargs)
+            if usuario:
+                self.fields['categoria'].queryset = Categorias_Entradas.objects.filter(usuario=usuario)

--- a/entradas/views.py
+++ b/entradas/views.py
@@ -62,6 +62,11 @@ class EntradasCreateView(LoginRequiredMixin, CreateView):
     template_name = 'entradas/entradas_create.html'
     success_url = reverse_lazy('entradas:entradas-list')
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['usuario'] = self.request.user
+        return kwargs
+
     def form_valid(self, form):
         form.instance.usuario = self.request.user
         return super().form_valid(form)
@@ -80,6 +85,11 @@ class EntradasUpdateView(LoginRequiredMixin, UpdateView):
     form_class = EntradasForm
     template_name = 'entradas/entradas_update.html'
     success_url = reverse_lazy('entradas:entradas-list')
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['usuario'] = self.request.user
+        return kwargs
 
     def get_queryset(self):
         return Entradas.objects.filter(usuario=self.request.user)

--- a/saidas/forms/saida_form.py
+++ b/saidas/forms/saida_form.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from saidas.models import Saidas
+from saidas.models import Saidas, Categorias_Saidas
 
 class SaidasForm(forms.ModelForm):
     class Meta:
@@ -33,3 +33,9 @@ class SaidasForm(forms.ModelForm):
             'descricao': 'Descrição',
             'valor': 'Valor',
         }
+    
+    def __init__(self, *args, **kwargs):
+            usuario = kwargs.pop('usuario', None)
+            super().__init__(*args, **kwargs)
+            if usuario:
+                self.fields['categoria'].queryset = Categorias_Saidas.objects.filter(usuario=usuario)

--- a/saidas/views.py
+++ b/saidas/views.py
@@ -51,6 +51,11 @@ class SaidasCreateView(LoginRequiredMixin, CreateView):
     form_class = SaidasForm
     success_url = reverse_lazy('saidas:saidas-list')
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['usuario'] = self.request.user
+        return kwargs
+
     def form_valid(self, form):
         form.instance.usuario = self.request.user
         return super().form_valid(form)
@@ -70,6 +75,11 @@ class SaidasUpdateView(LoginRequiredMixin, UpdateView):
     template_name = 'saidas/saidas_update.html'
     form_class = SaidasForm
     success_url = reverse_lazy('saidas:saidas-list')
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['usuario'] = self.request.user
+        return kwargs
 
     def get_queryset(self):
         return Saidas.objects.filter(usuario=self.request.user)


### PR DESCRIPTION
## O que foi feito
Corrigimos a seleção de entrada/saida nas páginas de formulário de entrada e saida, garantindo que a lista de opções seja exibida corretamente.

## Motivação
A correção foi necessária para resolver a falha reportada no sistema, onde os usuários estavam tendo dificuldade em selecionar a entrada/saida correta.

## Commits incluídos
- abcadb7 fix: Correção nos dados do select #42

## Observações
Essa mudança deve ser verificada nas páginas de entrada e saída para garantir que a seleção esteja funcionando corretamente.

## Como testar
Para testar a correção, acesse as páginas de entrada e saída e verifique se a lista de opções de entrada/saida está exibida corretamente. Certifique-se de que a ordem das opções também esteja correta.